### PR TITLE
修复：无法下载有花纹背景的图片

### DIFF
--- a/src/components/ComponentToImg.js
+++ b/src/components/ComponentToImg.js
@@ -38,6 +38,7 @@ const ComponentToImg = (props) => {
 		let data = await html2canvas(element, {
 			useCORS: true,
 			scale: 2,
+			backgroundColor: null,
 			allowTaint: true,
 			height: element.offsetHeight,
 			width: element.offsetWidth,


### PR DESCRIPTION
修复方法：使用 html2canvas@1.0.0-alpha.12 替换原本的 dom-to-image 依赖

Translation:
Fix: Unable to download images with patterned backgrounds Solution: Replace the original dependency of dom-to-image with html2canvas@1.0.0-alpha.12